### PR TITLE
Codex: Fix bitset copy and config serialization

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -991,8 +991,7 @@ export class MessageViewerConfig extends Data {
   toQuery(): URLSearchParams {
     const params = new URLSearchParams();
 
-    for (let key in this) {
-      const value = this[key];
+    for (const [key, value] of Object.entries(this)) {
       if (value != null) {
         params.set(key, value.toString());
       }

--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -381,17 +381,17 @@ export class BitSet {
 
   /** Set a bit to 1 at index. */
   set(index: number) {
-    this.bits[index >>> 5] |= ONE >>> index;
+    this.bits[index >>> 5] |= ONE >>> (index & 31);
   }
 
   /** Set a bit to 0 at index. */
   unset(index: number) {
-    this.bits[index >>> 5] &= ~(ONE >>> index);
+    this.bits[index >>> 5] &= ~(ONE >>> (index & 31));
   }
 
   /** Check if an index is set. */
   includes(index: number) {
-    return (this.bits[index >>> 5] & (ONE >>> index)) !== 0;
+    return (this.bits[index >>> 5] & (ONE >>> (index & 31))) !== 0;
   }
 
   /**
@@ -400,7 +400,7 @@ export class BitSet {
    */
   predicate() {
     let bits = this.bits;
-    return (index: number) => (bits[index >>> 5] & (ONE >>> index)) !== 0;
+    return (index: number) => (bits[index >>> 5] & (ONE >>> (index & 31))) !== 0;
   }
 
   /**
@@ -419,7 +419,7 @@ export class BitSet {
   }
 
   copy() {
-    const copy = new BitSet(0);
+    const copy = new BitSet(this.capacity);
     copy.bits = this.bits.slice();
     return copy;
   }


### PR DESCRIPTION
## Summary
- maintain capacity when copying BitSet
- iterate over own properties when serializing message viewer config
- handle indexes over 31 bits correctly in BitSet

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition files)*
- `npx gulp test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/gulp)*

------
https://chatgpt.com/codex/tasks/task_e_684a22ae43ec83208fdc0d957078ed04