### PR TITLE
fix mocha timeouts in CI

### DIFF
--- a/tests/stubs/inMemoryMemento.ts
+++ b/tests/stubs/inMemoryMemento.ts
@@ -1,0 +1,22 @@
+import { Memento } from "vscode";
+
+export class InMemoryMemento implements Memento {
+  private store = new Map<string, any>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key);
+  }
+
+  update(key: string, value: any): Thenable<void> {
+    if (value === undefined) {
+      this.store.delete(key);
+    } else {
+      this.store.set(key, value);
+    }
+    return Promise.resolve();
+  }
+
+  keys(): readonly string[] {
+    return Array.from(this.store.keys());
+  }
+}

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { InMemoryMemento } from "../stubs/inMemoryMemento";
 import { KafkaTopicOperation } from "../../src/authz/types";
 import { TopicData, TopicDataFromJSON } from "../../src/clients/kafkaRest/models";
 import { ResponseError } from "../../src/clients/sidecar";
@@ -51,6 +52,9 @@ export async function getTestExtensionContext(
   const extension = await getAndActivateExtension(id);
   // this only works because we explicitly return the ExtensionContext in our activate() function
   const context = extension.exports;
+  if (process.env.CI === "true") {
+    (context as any).workspaceState = new InMemoryMemento();
+  }
   setExtensionContext(context);
   return context;
 }


### PR DESCRIPTION
## Summary
- use an in-memory `Memento` for `workspaceState` when tests run in CI

## Testing
- `npx gulp test` *(fails: Could not download sidecar executable)*

------
https://chatgpt.com/codex/tasks/task_e_6864b55e57308320be4fad3fb3713296