### PR TITLE
feat: add multi-mode Flink artifacts view

### DIFF
--- a/package.json
+++ b/package.json
@@ -448,6 +448,18 @@
         "category": "Confluent: Flink Artifacts"
       },
       {
+        "command": "confluent.flink.artifacts.mode.artifacts",
+        "icon": "$(folder-library)",
+        "title": "Show Artifacts",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
+        "command": "confluent.flink.artifacts.mode.udfs",
+        "icon": "$(symbol-function)",
+        "title": "Show UDFs",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
         "command": "confluent.statements.refresh",
         "icon": "$(sync)",
         "title": "Refresh",
@@ -1164,7 +1176,12 @@
       {
         "view": "confluent-flink-artifacts",
         "contents": "No Flink artifacts found.",
-        "when": "config.confluent.flink.enableFlinkArtifacts && confluent.ccloudConnectionAvailable && confluent.flinkArtifactsPoolSelected"
+        "when": "config.confluent.flink.enableFlinkArtifacts && confluent.ccloudConnectionAvailable && confluent.flinkArtifactsPoolSelected && confluent.flinkArtifactsMode == 'artifacts'"
+      },
+      {
+        "view": "confluent-flink-artifacts",
+        "contents": "No Flink user-defined functions found.",
+        "when": "config.confluent.flink.enableFlinkArtifacts && confluent.ccloudConnectionAvailable && confluent.flinkArtifactsPoolSelected && confluent.flinkArtifactsMode == 'udfs'"
       }
     ],
     "menus": {
@@ -1521,6 +1538,16 @@
           "command": "confluent.artifacts.flink-compute-pool.select",
           "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@1"
+        },
+        {
+          "command": "confluent.flink.artifacts.mode.udfs",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsMode == 'artifacts'",
+          "group": "navigation@2"
+        },
+        {
+          "command": "confluent.flink.artifacts.mode.artifacts",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsMode == 'udfs'",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -1,0 +1,16 @@
+import { Disposable } from "vscode";
+import { registerCommandWithLogging } from ".";
+import { FlinkArtifactsViewProvider } from "../viewProviders/flinkArtifacts";
+
+export function registerFlinkArtifactCommands(): Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.flink.artifacts.mode.artifacts", async () => {
+      const view = FlinkArtifactsViewProvider.getInstance();
+      await view.switchToArtifacts();
+    }),
+    registerCommandWithLogging("confluent.flink.artifacts.mode.udfs", async () => {
+      const view = FlinkArtifactsViewProvider.getInstance();
+      await view.switchToUdfs();
+    }),
+  ];
+}

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -64,6 +64,8 @@ export enum ContextValues {
   flinkStatementsPoolSelected = "confluent.flinkStatementsPoolSelected",
   /** The user focused a Flink compute pool for the Flink Artifacts view. */
   flinkArtifactsPoolSelected = "confluent.flinkArtifactsPoolSelected",
+  /** Current mode of the Flink Artifacts view. */
+  flinkArtifactsMode = "confluent.flinkArtifactsMode",
   /** The user applied a search string to the Resources view. */
   resourceSearchApplied = "confluent.resourceSearchApplied",
   /** The user applied a search string to the Topics view. */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { registerDocumentCommands } from "./commands/documents";
 import { registerEnvironmentCommands } from "./commands/environments";
 import { registerExtraCommands } from "./commands/extra";
 import { registerFlinkComputePoolCommands } from "./commands/flinkComputePools";
+import { registerFlinkArtifactCommands } from "./commands/flinkArtifacts";
 import { registerFlinkStatementCommands } from "./commands/flinkStatements";
 import { registerKafkaClusterCommands } from "./commands/kafkaClusters";
 import { registerOrganizationCommands } from "./commands/organizations";
@@ -253,6 +254,7 @@ async function _activateExtension(
     ...registerDockerCommands(),
     ...registerProjectGenerationCommands(),
     ...registerFlinkComputePoolCommands(),
+    ...registerFlinkArtifactCommands(),
     ...registerFlinkStatementCommands(),
     ...registerDocumentCommands(),
     ...registerSearchCommands(),
@@ -349,6 +351,7 @@ async function setupContextValues() {
   // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
   const kafkaClusterSelected = setContextValue(ContextValues.kafkaClusterSelected, false);
   const schemaRegistrySelected = setContextValue(ContextValues.schemaRegistrySelected, false);
+  const flinkArtifactsMode = setContextValue(ContextValues.flinkArtifactsMode, "artifacts");
   // constants for easier `when` clause matching in package.json; not updated dynamically
   const openInCCloudResources = setContextValue(ContextValues.CCLOUD_RESOURCES, [
     "ccloud-environment",
@@ -411,6 +414,7 @@ async function setupContextValues() {
     chatParticipantEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,
+    flinkArtifactsMode,
     openInCCloudResources,
     viewsWithResources,
     resourcesWithIds,

--- a/src/models/flinkUdf.ts
+++ b/src/models/flinkUdf.ts
@@ -1,0 +1,50 @@
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ConnectionType } from "../clients/sidecar";
+import { IconNames } from "../constants";
+import { IdItem } from "./main";
+import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+
+export class FlinkUdf implements IResourceBase, IdItem, ISearchable {
+  connectionId!: ConnectionId;
+  connectionType!: ConnectionType;
+  iconName: IconNames = IconNames.FLINK_ARTIFACT;
+
+  environmentId!: EnvironmentId;
+
+  id!: string;
+  name!: string;
+  description!: string;
+
+  constructor(
+    props: Pick<
+      FlinkUdf,
+      "connectionId" | "connectionType" | "environmentId" | "id" | "name" | "description"
+    >,
+  ) {
+    this.connectionId = props.connectionId;
+    this.connectionType = props.connectionType;
+    this.environmentId = props.environmentId;
+    this.id = props.id;
+    this.name = props.name;
+    this.description = props.description;
+  }
+
+  searchableText(): string {
+    return `${this.name} ${this.description}`;
+  }
+}
+
+export class FlinkUdfTreeItem extends TreeItem {
+  resource: FlinkUdf;
+
+  constructor(resource: FlinkUdf) {
+    super(resource.name, TreeItemCollapsibleState.None);
+
+    this.id = resource.id;
+    this.resource = resource;
+    this.contextValue = `${resource.connectionType.toLowerCase()}-flink-udf`;
+
+    this.iconPath = new ThemeIcon(resource.iconName);
+    this.description = resource.description;
+  }
+}

--- a/src/viewProviders/flinkArtifacts.test.ts
+++ b/src/viewProviders/flinkArtifacts.test.ts
@@ -9,7 +9,7 @@ import { ResponseError } from "../clients/flinkArtifacts";
 import * as errors from "../errors";
 import { CCloudResourceLoader } from "../loaders";
 import * as notifications from "../notifications";
-import { FlinkArtifactsViewProvider } from "./flinkArtifacts";
+import { FlinkArtifactsViewMode, FlinkArtifactsViewProvider } from "./flinkArtifacts";
 
 describe("FlinkArtifactsViewProvider", () => {
   let sandbox: sinon.SinonSandbox;
@@ -53,8 +53,11 @@ describe("FlinkArtifactsViewProvider", () => {
       // Should clear the artifacts array and fire the change event.
       await viewProvider.refresh();
 
+      const artifactsMode = (viewProvider as any)["modes"].get(
+        FlinkArtifactsViewMode.Artifacts,
+      ) as any;
       sinon.assert.calledOnce(changeFireStub);
-      assert.deepStrictEqual(viewProvider["_artifacts"], []);
+      assert.deepStrictEqual(artifactsMode["artifacts"], []);
     });
 
     it("fetches new artifacts when a resource is selected", async () => {
@@ -83,7 +86,10 @@ describe("FlinkArtifactsViewProvider", () => {
       sinon.assert.calledTwice(changeFireStub);
       sinon.assert.calledOnce(stubbedLoader.getFlinkArtifacts);
       sinon.assert.calledWith(stubbedLoader.getFlinkArtifacts, resource);
-      assert.deepStrictEqual(viewProvider["_artifacts"], mockArtifacts);
+      const artifactsMode = (viewProvider as any)["modes"].get(
+        FlinkArtifactsViewMode.Artifacts,
+      ) as any;
+      assert.deepStrictEqual(artifactsMode["artifacts"], mockArtifacts);
     });
 
     it("returns artifacts when compute pool is selected", () => {
@@ -95,7 +101,10 @@ describe("FlinkArtifactsViewProvider", () => {
       ];
 
       viewProvider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-      viewProvider["_artifacts"] = mockArtifacts;
+      const artifactsMode = (viewProvider as any)["modes"].get(
+        FlinkArtifactsViewMode.Artifacts,
+      ) as any;
+      artifactsMode["artifacts"] = mockArtifacts;
 
       const children = viewProvider.getChildren();
       assert.deepStrictEqual(children, mockArtifacts);
@@ -185,7 +194,10 @@ describe("FlinkArtifactsViewProvider", () => {
         const mockError = new ResponseError(new Response("test error", { status: undefined }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        viewProvider["_artifacts"] = [
+        const artifactsMode = (viewProvider as any)["modes"].get(
+          FlinkArtifactsViewMode.Artifacts,
+        ) as any;
+        artifactsMode["artifacts"] = [
           createFlinkArtifact({
             id: "artifact1",
             name: "Initial Artifact",
@@ -196,8 +208,11 @@ describe("FlinkArtifactsViewProvider", () => {
           await viewProvider.refresh();
         }, mockError);
 
+        const artifactsModeAfter = (viewProvider as any)["modes"].get(
+          FlinkArtifactsViewMode.Artifacts,
+        ) as any;
         // Artifacts should be cleared at the start of refresh
-        assert.deepStrictEqual(viewProvider["_artifacts"], []);
+        assert.deepStrictEqual(artifactsModeAfter["artifacts"], []);
 
         // Should fire change event once at start to clear (error prevents final fire call)
         sinon.assert.calledOnce(changeFireStub);


### PR DESCRIPTION
## Summary
- add MultiModeViewProvider to allow switching view modes
- support artifacts and UDF modes in Flink artifacts view
- register commands and context values for mode switching

## Testing
- `npx gulp test` *(fails: Sidecar executable ide-sidecar-0.227.0-runner not found)*
- `npx eslint src/viewProviders/base.ts src/viewProviders/flinkArtifacts.ts src/models/flinkUdf.ts src/commands/flinkArtifacts.ts src/context/values.ts src/extension.ts src/viewProviders/flinkArtifacts.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6892b1a167008320b4d15f350cfd7397