### PR TITLE
feat: support multi-mode Flink artifacts view

### DIFF
--- a/package.json
+++ b/package.json
@@ -448,6 +448,16 @@
         "category": "Confluent: Flink Artifacts"
       },
       {
+        "command": "confluent.artifacts.viewUDFs",
+        "title": "View UDFs",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
+        "command": "confluent.artifacts.viewArtifacts",
+        "title": "View Flink Artifacts",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
         "command": "confluent.statements.refresh",
         "icon": "$(sync)",
         "title": "Refresh",
@@ -1521,6 +1531,16 @@
           "command": "confluent.artifacts.flink-compute-pool.select",
           "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@1"
+        },
+        {
+          "command": "confluent.artifacts.viewUDFs",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsMode == artifacts",
+          "group": "navigation@2"
+        },
+        {
+          "command": "confluent.artifacts.viewArtifacts",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsMode == udfs",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -1,0 +1,18 @@
+import * as vscode from "vscode";
+import { registerCommandWithLogging } from ".";
+import { FlinkArtifactsViewProvider } from "../viewProviders/flinkArtifacts";
+
+function switchMode(mode: string): void {
+  FlinkArtifactsViewProvider.getInstance().switchMode(mode);
+}
+
+export function registerFlinkArtifactCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.artifacts.viewArtifacts", () =>
+      switchMode("artifacts"),
+    ),
+    registerCommandWithLogging("confluent.artifacts.viewUDFs", () =>
+      switchMode("udfs"),
+    ),
+  ];
+}

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -74,6 +74,8 @@ export enum ContextValues {
   flinkStatementsSearchApplied = "confluent.flinkStatementsSearchApplied",
   /** The user applied a search string to the Flink Artifacts view. */
   flinkArtifactsSearchApplied = "confluent.flinkArtifactsSearchApplied",
+  /** Current mode for the Flink Artifacts view. */
+  flinkArtifactsMode = "confluent.flinkArtifactsMode",
   /**
    * EXPERIMENTAL: Is the chat participant enabled?
    * (This should go away once the `confluent.experimental.enableChatParticipant` setting is removed.)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { registerSearchCommands } from "./commands/search";
 import { registerSupportCommands } from "./commands/support";
 import { registerTopicCommands } from "./commands/topics";
 import { registerUploadUDFCommand } from "./commands/uploadUDF";
+import { registerFlinkArtifactCommands } from "./commands/flinkArtifacts";
 import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL, IconNames } from "./constants";
 import { activateMessageViewer } from "./consume";
 import { setExtensionContext } from "./context/extension";
@@ -254,6 +255,7 @@ async function _activateExtension(
     ...registerProjectGenerationCommands(),
     ...registerFlinkComputePoolCommands(),
     ...registerFlinkStatementCommands(),
+    ...registerFlinkArtifactCommands(),
     ...registerDocumentCommands(),
     ...registerSearchCommands(),
     registerUploadUDFCommand(),
@@ -378,6 +380,7 @@ async function setupContextValues() {
     "ccloud-schema-registry", // only ID, no name
     "ccloud-flink-compute-pool",
     "ccloud-flink-artifact",
+    "ccloud-flink-udf",
     "local-kafka-cluster",
     "local-schema-registry",
     "direct-kafka-cluster",
@@ -392,6 +395,7 @@ async function setupContextValues() {
     "ccloud-flink-compute-pool",
     "ccloud-flink-statement",
     "ccloud-flink-artifact",
+    "ccloud-flink-udf",
     "local-kafka-cluster",
     "direct-kafka-cluster",
     // topics also have names, but their context values vary wildly and must be regex-matched
@@ -407,6 +411,10 @@ async function setupContextValues() {
     SCHEMA_URI_SCHEME,
     MESSAGE_URI_SCHEME,
   ]);
+  const flinkArtifactsMode = setContextValue(
+    ContextValues.flinkArtifactsMode,
+    "artifacts",
+  );
   await Promise.all([
     chatParticipantEnabled,
     kafkaClusterSelected,
@@ -417,6 +425,7 @@ async function setupContextValues() {
     resourcesWithNames,
     resourcesWithURIs,
     diffableResources,
+    flinkArtifactsMode,
   ]);
 }
 

--- a/src/models/flinkUdf.ts
+++ b/src/models/flinkUdf.ts
@@ -1,0 +1,50 @@
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ConnectionType } from "../clients/sidecar";
+import { IconNames } from "../constants";
+import { IdItem } from "./main";
+import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+
+export class FlinkUdf implements IResourceBase, IdItem, ISearchable {
+  connectionId!: ConnectionId;
+  connectionType!: ConnectionType;
+  iconName: IconNames = IconNames.FLINK_ARTIFACT;
+
+  environmentId!: EnvironmentId;
+
+  id!: string;
+  name!: string;
+  description!: string;
+
+  constructor(
+    props: Pick<
+      FlinkUdf,
+      "connectionId" | "connectionType" | "environmentId" | "id" | "name" | "description"
+    >,
+  ) {
+    this.connectionId = props.connectionId;
+    this.connectionType = props.connectionType;
+    this.environmentId = props.environmentId;
+    this.id = props.id;
+    this.name = props.name;
+    this.description = props.description;
+  }
+
+  searchableText(): string {
+    return `${this.name} ${this.description}`;
+  }
+}
+
+export class FlinkUdfTreeItem extends TreeItem {
+  resource: FlinkUdf;
+
+  constructor(resource: FlinkUdf) {
+    super(resource.name, TreeItemCollapsibleState.None);
+
+    this.id = resource.id;
+    this.resource = resource;
+    this.contextValue = `${resource.connectionType.toLowerCase()}-flink-udf`;
+
+    this.iconPath = new ThemeIcon(resource.iconName);
+    this.description = resource.description;
+  }
+}


### PR DESCRIPTION
## Summary
- add MultiModeViewProvider to support switching tree view modes
- support UDF mode in Flink Artifacts view and add commands to toggle modes
- wire up commands, context values, and model for UDFs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Module './apis/index' has already exported a member named 'RegisterExporterRequest'. Consider explicitly re-exporting to resolve the ambiguity., Module '../models/index' has no exported member 'ApplyTemplateRequest'.)*

------
https://chatgpt.com/codex/tasks/task_e_6892b1a167008320b4d15f350cfd7397