### PR TITLE
feat: add UDF mode to Flink artifacts view

### DIFF
--- a/package.json
+++ b/package.json
@@ -448,6 +448,18 @@
         "category": "Confluent: Flink Artifacts"
       },
       {
+        "command": "confluent.artifacts.view-mode.udfs",
+        "icon": "$(symbol-function)",
+        "title": "View UDFs",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
+        "command": "confluent.artifacts.view-mode.artifacts",
+        "icon": "$(folder-library)",
+        "title": "View Artifacts",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
         "command": "confluent.statements.refresh",
         "icon": "$(sync)",
         "title": "Refresh",
@@ -1521,6 +1533,16 @@
           "command": "confluent.artifacts.flink-compute-pool.select",
           "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@1"
+        },
+        {
+          "command": "confluent.artifacts.view-mode.udfs",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsViewMode == artifacts",
+          "group": "navigation@2"
+        },
+        {
+          "command": "confluent.artifacts.view-mode.artifacts",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsViewMode == udfs",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode";
+import { registerCommandWithLogging } from ".";
+import { FlinkArtifactsViewProvider } from "../viewProviders/flinkArtifacts";
+
+export async function viewUdfMode(): Promise<void> {
+  const provider = FlinkArtifactsViewProvider.getInstance();
+  await provider.setMode("udfs");
+}
+
+export async function viewArtifactMode(): Promise<void> {
+  const provider = FlinkArtifactsViewProvider.getInstance();
+  await provider.setMode("artifacts");
+}
+
+export function registerFlinkArtifactsCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.artifacts.view-mode.udfs", viewUdfMode),
+    registerCommandWithLogging("confluent.artifacts.view-mode.artifacts", viewArtifactMode),
+  ];
+}

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -74,6 +74,7 @@ export enum ContextValues {
   flinkStatementsSearchApplied = "confluent.flinkStatementsSearchApplied",
   /** The user applied a search string to the Flink Artifacts view. */
   flinkArtifactsSearchApplied = "confluent.flinkArtifactsSearchApplied",
+  flinkArtifactsViewMode = "confluent.flinkArtifactsViewMode",
   /**
    * EXPERIMENTAL: Is the chat participant enabled?
    * (This should go away once the `confluent.experimental.enableChatParticipant` setting is removed.)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { registerSearchCommands } from "./commands/search";
 import { registerSupportCommands } from "./commands/support";
 import { registerTopicCommands } from "./commands/topics";
 import { registerUploadUDFCommand } from "./commands/uploadUDF";
+import { registerFlinkArtifactsCommands } from "./commands/flinkArtifacts";
 import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL, IconNames } from "./constants";
 import { activateMessageViewer } from "./consume";
 import { setExtensionContext } from "./context/extension";
@@ -254,6 +255,7 @@ async function _activateExtension(
     ...registerProjectGenerationCommands(),
     ...registerFlinkComputePoolCommands(),
     ...registerFlinkStatementCommands(),
+    ...registerFlinkArtifactsCommands(),
     ...registerDocumentCommands(),
     ...registerSearchCommands(),
     registerUploadUDFCommand(),

--- a/src/models/flinkUdf.ts
+++ b/src/models/flinkUdf.ts
@@ -1,0 +1,50 @@
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ConnectionType } from "../clients/sidecar";
+import { IconNames } from "../constants";
+import { IdItem } from "./main";
+import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+
+export class FlinkUdf implements IResourceBase, IdItem, ISearchable {
+  connectionId!: ConnectionId;
+  connectionType!: ConnectionType;
+  iconName: IconNames = IconNames.FLINK_ARTIFACT;
+
+  environmentId!: EnvironmentId;
+
+  id!: string;
+  name!: string;
+  description!: string;
+
+  constructor(
+    props: Pick<
+      FlinkUdf,
+      "connectionId" | "connectionType" | "environmentId" | "id" | "name" | "description"
+    >,
+  ) {
+    this.connectionId = props.connectionId;
+    this.connectionType = props.connectionType;
+    this.environmentId = props.environmentId;
+    this.id = props.id;
+    this.name = props.name;
+    this.description = props.description;
+  }
+
+  searchableText(): string {
+    return `${this.name} ${this.description}`;
+  }
+}
+
+export class FlinkUdfTreeItem extends TreeItem {
+  resource: FlinkUdf;
+
+  constructor(resource: FlinkUdf) {
+    super(resource.name, TreeItemCollapsibleState.None);
+
+    this.id = resource.id;
+    this.resource = resource;
+    this.contextValue = `${resource.connectionType.toLowerCase()}-flink-udf`;
+
+    this.iconPath = new ThemeIcon(resource.iconName);
+    this.description = resource.description;
+  }
+}


### PR DESCRIPTION
## Summary
- add `MultiModeViewProvider` to support multiple modes
- add UDF mode and switching commands for Flink artifacts view
- add FlinkUdf model and context tracking

## Testing
- `npx gulp check`
- `npx gulp lint`
- `npx gulp test` *(fails: Failed to get JSON)*
- `npx gulp build`


------
https://chatgpt.com/codex/tasks/task_e_6892b7c3cdf48320aa80f861f0123424